### PR TITLE
Refactor retry logic and add .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+build
+dist
+venv
+main.spec

--- a/settingsGUI.py
+++ b/settingsGUI.py
@@ -74,7 +74,6 @@ def update_pp_label():
 
 def get_pp_from_input():
     pp_url = f"http://127.0.0.1:24050/api/calculate/pp?n100={hitDict['100']}&n50={hitDict['50']}&nMisses={hitDict['0']}&mods={hitDict['Mods']}"
-    
     try:
         response = requests.get(pp_url)
         responseData = response.json()


### PR DESCRIPTION
Used a different method to prevent the double retry bug
The original method was to clear the user defined `hitDict` and reinstate it after the retry.
The issue with this was that this would occur before Tosu would report the new hit statuses on the API, so the program would think that the current play was still going on.

# New approach:
Using the live time and first object time given in the Tosu API, i can have a cooldown hold (cant think of a better name) that gets enabled/disabled whenever a retry is ran. When the API returns that a new map is started, given by `liveTime <= firstObject` it is safe to assume the map has restarted and another retry will not succeed.